### PR TITLE
Provide a default state to the reducer

### DIFF
--- a/source/utils.js
+++ b/source/utils.js
@@ -7,7 +7,7 @@ export function next(state) {
   return put({ type: RETURN, next: state })
 }
 
-export function reducer(state, { type, next }) {
+export function reducer(state = {}, { type, next }) {
   if (type === RETURN) return next;
   return state;
 }


### PR DESCRIPTION
Reducers should return an empty state if none is provided. This ensures that.